### PR TITLE
Add support for I2C interface

### DIFF
--- a/ssd1306/main.py
+++ b/ssd1306/main.py
@@ -1,10 +1,17 @@
 import pyb
 from ssd1306 import SSD1306
 
+# SPI
 display = SSD1306(pinout={'dc': 'Y3',
                           'res': 'Y4'},
                   height=64,
                   external_vcc=False)
+
+# I2C connected to Y9, Y10 (I2C bus 2)
+##display = SSD1306(pinout={'sda': 'Y10',
+##                          'scl': 'Y9'},
+##                  height=64,
+##                  external_vcc=False)
 
 led_red = pyb.LED(1)
 led_red.off()


### PR DESCRIPTION
Hi,
I bought an SSD1306-based OLED display on ebay and it only pins-out the I2C interface. Using your code as a starting point I hacked in I2C support and then merged my changes back so that the code supports either I2C or SPI. I hope you will accept my changes back into your repository so that it can act as a single location for SSD1306 support on the micropython board.

I'm a new Python programmer and a github newbie also so tell me if I have made any protocol errors here.
regards,
Neal.
